### PR TITLE
arreglos en el paginado y en la home

### DIFF
--- a/client/src/components/Home/Home.css
+++ b/client/src/components/Home/Home.css
@@ -4,8 +4,6 @@
 
 .contenedor-Home {
     padding-top: 80px;
-    border-color: black;
-    border-width: 2px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -24,12 +22,11 @@
 }
 
 .contenedor-Home2 {
-    border-color: black;
-    border-width: 2px;
     margin: 10px;
     min-height: 400px;
     width: 98%;
     display: flex;
+    justify-content: center;
 }
 
 .contenedor-Filtros {
@@ -40,13 +37,12 @@
 }
 
 .contenedor-Home3 {
-    border-color: black;
-    border-width: 2px;
     margin: 10px;
-    width: 73%;
+    width: 60%;
     display: flex;
     flex-direction: column;
     align-items: center;
+
 }
 
 .contenedor-Cards {

--- a/client/src/components/Home/Home.jsx
+++ b/client/src/components/Home/Home.jsx
@@ -18,9 +18,10 @@ export default function Home() {
   const indexLastCar = currentPage * carsPerPage; //[3]Indice del ultimo car por pagina
   const indexFirstCar = indexLastCar - carsPerPage; //[0]Indice del primer car por pagina
   const currentCarsPerPage = cars.slice(indexFirstCar, indexLastCar); //[0,1,2] Arreglo con los cars por pagina
-const estilos={gradienteazul:"text-white bg-gradient-to-r from-cyan-500 to-blue-500 hover:bg-gradient-to-bl focus:ring-4 focus:outline-none focus:ring-cyan-300 dark:focus:ring-cyan-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2"
-    
-}
+  const estilos = {
+    gradienteazul: "text-white bg-gradient-to-r from-cyan-500 to-blue-500 hover:bg-gradient-to-bl focus:ring-4 focus:outline-none focus:ring-cyan-300 dark:focus:ring-cyan-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2"
+  }
+
   //FUNCIONES DEL PAGINADO
   const paginate = (pageNumber) => {
     //Modifica el numero de paginado
@@ -35,6 +36,10 @@ const estilos={gradienteazul:"text-white bg-gradient-to-r from-cyan-500 to-blue-
     dispatch(getCars());
   }, [dispatch]);
 
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [cars]);
+
   return (
     <div className="contenedor">
       <div>
@@ -43,10 +48,10 @@ const estilos={gradienteazul:"text-white bg-gradient-to-r from-cyan-500 to-blue-
       <div className="contenedor-Home">
         <div className="contenedor-Home2">
           <div className={estilos.gradienteazul}>
-          <Filters />
+            <Filters />
           </div>
           <div className="contenedor-Home3">
-            <div class="grid grid-cols-3 gap-3">
+            <div class="grid grid-cols-3 gap-0">
               {currentCarsPerPage?.map((el) => {
                 return (
                   <Card
@@ -69,6 +74,7 @@ const estilos={gradienteazul:"text-white bg-gradient-to-r from-cyan-500 to-blue-
                 page={currentPage}
                 number={number}
                 numberPaginate={numberPaginate}
+                cars={cars}
               />
             </div>
           </div>

--- a/client/src/components/Paginado/Paginado.jsx
+++ b/client/src/components/Paginado/Paginado.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 
 
-export default function Paginado({ allCars, carsPerPage, paginate, page, number, numberPaginate }) {
+export default function Paginado({ allCars, carsPerPage, paginate, page, number, numberPaginate, cars }) {
 
-    
+
     const pageNumber = [];//Numero de paginado por cada 3 cars
     for (let i = 1; i <= Math.ceil(allCars / carsPerPage); i++) {
         pageNumber.push(i);
@@ -16,9 +16,8 @@ export default function Paginado({ allCars, carsPerPage, paginate, page, number,
 
     const previous = () => {
         if (page > 1) paginate(page - 1)
-        if (page < number + 1 && page > 1 ) numberPaginate(number - 1);
+        if (page < number + 1 && page > 1) numberPaginate(number - 1);
     }
-    console.log(page);
 
     return (
         <nav aria-label="Page navigation example">
@@ -35,17 +34,23 @@ export default function Paginado({ allCars, carsPerPage, paginate, page, number,
                         {number}
                     </button>
                 </li>
-                <li>
-                    <button onClick={() => { paginate(number + 1) }} class={page === number + 1 ? "text-white shadow-md shadow-black bg-blue-900 hover:bg-blue-900 focus:outline-none focus:ring-4 focus:ring-blue-900 font-medium rounded-lg text-lg px-5 py-2.5 text-center mr-2 mb-2 dark:focus:ring-blue-900 " : "text-white shadow-md shadow-black bg-blue-900 hover:bg-blue-900 focus:outline-none focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-lg px-5 py-2.5 text-center mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-900 dark:focus:ring-blue-900"}>
-                        {number + 1}
-                    </button>
-                </li>
-                <li>
-                    <button onClick={() => { paginate(number + 2) }} class={page === number + 2 ? "text-white shadow-md shadow-black bg-blue-900 hover:bg-blue-900 focus:outline-none focus:ring-4 focus:ring-blue-900 font-medium rounded-lg text-lg px-5 py-2.5 text-center mr-2 mb-2 dark:focus:ring-blue-900 " : "text-white shadow-md shadow-black bg-blue-900 hover:bg-blue-900 focus:outline-none focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-lg px-5 py-2.5 text-center mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-900 dark:focus:ring-blue-900"}>
-                        {number + 2}
-                    </button>
-                </li>
+                {
+                    cars.length >= carsPerPage * 2 && (
+                        <li>
+                            <button onClick={() => { paginate(number + 1) }} class={page === number + 1 ? "text-white shadow-md shadow-black bg-blue-900 hover:bg-blue-900 focus:outline-none focus:ring-4 focus:ring-blue-900 font-medium rounded-lg text-lg px-5 py-2.5 text-center mr-2 mb-2 dark:focus:ring-blue-900 " : "text-white shadow-md shadow-black bg-blue-900 hover:bg-blue-900 focus:outline-none focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-lg px-5 py-2.5 text-center mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-900 dark:focus:ring-blue-900"}>
+                                {number + 1}
+                            </button>
+                        </li>
+                    )}
 
+                {
+                    cars.length >= carsPerPage * 3 && (
+                        <li>
+                            <button onClick={() => { paginate(number + 2) }} class={page === number + 2 ? "text-white shadow-md shadow-black bg-blue-900 hover:bg-blue-900 focus:outline-none focus:ring-4 focus:ring-blue-900 font-medium rounded-lg text-lg px-5 py-2.5 text-center mr-2 mb-2 dark:focus:ring-blue-900 " : "text-white shadow-md shadow-black bg-blue-900 hover:bg-blue-900 focus:outline-none focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-lg px-5 py-2.5 text-center mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-900 dark:focus:ring-blue-900"}>
+                                {number + 2}
+                            </button>
+                        </li>
+                    )}
                 <li>
                     <button onClick={() => { next() }} class="text-white rounded-r-lg shadow-md shadow-black bg-blue-900 hover:bg-blue-900 focus:outline-none   font-medium text-lg px-4 py-3 text-center mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-900 dark:focus:ring-blue-800">
                         <span class="sr-only">Next</span>


### PR DESCRIPTION
**Arreglo en el paginado, cuando se actualiza el estado cars se vaya directamente a la pagina 1, ademas de borrar los botones si solo hay carros en la pagina 1. modifique el home, centre el contenedor de los filtros y las cards**

![image](https://user-images.githubusercontent.com/91912933/196043533-ae3702d7-77a8-4721-bb41-9087ebee56aa.png)
